### PR TITLE
add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,23 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-vXiKURtntURybE6FMNFAVpRPr8+e8KoLPrYs9TGuAKc=",
+        "path": "/nix/store/9axrw7zwqjmx17sghgndrbr8q00xi61z-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "Aptakube AppImage";
+
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.default = let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+    in pkgs.appimageTools.wrapType2 {
+      name = "aptakube";
+      src = pkgs.fetchurl {
+        url = "https://releases.aptakube.com/aptakube_1.11.4_amd64.AppImage";
+        hash = "sha256-G5E7qqWA53W/6SPEZmvqKKcm+INo45L48W5PLdtmmU0=";
+      };
+    };
+  };
+}


### PR DESCRIPTION
This allows Nix/NixOS users to include Aptakube into their config.

To update the hash, update the url, run `nix build .` on an x86 Linux machine and grab the new hash from the error message.